### PR TITLE
PR for #11: Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Each folder hosts an `/output/` subfolder where output from each script is saved
 ### Citations
 
 * Hermo, Santiago, Christian Lundqvist, Miika Päällysaho, David Seim, Jesse M. Shapiro, and Stina Trollbäck. 2022. LaroplanOCR. Code and data repository at <https://github.com/JMSLab/LaroplanOCR>.
-* Hermo, Santiago, Miika Päällysaho, David Seim, and  Jesse M. Shapiro. 2022. Labor Market Returns and the Evolution of Cognitive Skills: Theory and Evidence. NBER Working Paper Number 29135. URL: <https://www.nber.org/papers/w29135>.
+* Hermo, Santiago, Miika Päällysaho, David Seim, and  Jesse M. Shapiro. 2022. Labor Market Returns and the Evolution of Cognitive Skills: Theory and Evidence. The Quarterly Journal of Economics, Volume 137, Issue 4, November 2022, Pages 2309–2361. DOI: <https://doi.org/10.1093/qje/qjac022>.
 
 
 ### Acknowledgments

--- a/log/release.log
+++ b/log/release.log
@@ -1,6 +1,6 @@
-Started at 03:53:02PM Eastern Daylight Time on Apr 07, 2022
+Started at 10:26:10AM Eastern Daylight Time on Sep 21, 2022
 
-03:53:02PM   : Compilation of codebook.md started
-03:53:08PM   : Build of release.zip started
+10:26:10AM   : Compilation of codebook.md started
+10:26:39AM   : Build of release.zip started
 
-Finished at 03:53:09PM Eastern Daylight Time on Apr 07, 2022
+Finished at 10:26:41AM Eastern Daylight Time on Sep 21, 2022


### PR DESCRIPTION
In this branch, follow-up from #11, I updated the citation in the main README. 

- The new compiled release is [release.zip](https://github.com/JMSLab/LaroplanOCR/files/9617671/release.zip)
- The new codebook, the only file that change, is [codebook.pdf](https://github.com/JMSLab/LaroplanOCR/files/9617642/codebook.pdf)
- The [Harvard Dataverse release](https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi%3A10.7910%2FDVN%2FEEPBEU&version=DRAFT) was updated: 1) I changed metadata to reflect the new citation, 2) I updated codebook.pdf

Tasks:
- Make sure the new citation is correct (@jmshapir, @miikapaal)
- If so, publish the changes in the Havard Dataverse release (@jmshapir)
- Squash and merge (@santiagohermo)
- Release version v1.0.1 with the updated citation (@santiagohermo)
